### PR TITLE
Updated regex for netid validation

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -31,7 +31,7 @@ class User
                     end
         return [400, 'UIN must be an integer'] unless int_value
       when :netid
-        invalid_netid = /^[a-z]{3,7}[2-9]{1,4}$/.match(params[:netid]).nil? ||
+        invalid_netid = /^[a-z]{2,7}[2-9]{1,4}$/.match(params[:netid]).nil? ||
                         params[:netid].length > 8
         return [400, 'A valid netid must be entered'] if invalid_netid
       end


### PR DESCRIPTION
A user with the netid in the form "XX1" was trying to log in, but this failed validation. This reduces the number of required letters to 2 from 3.